### PR TITLE
Fixed opening URL in browser for authorisation on windows

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -94,7 +94,7 @@ func openURL(url string) error {
 	case "linux":
 		err = exec.Command("xdg-open", url).Start()
 	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", "http://localhost:4001/").Start()
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
 	case "darwin":
 		err = exec.Command("open", url).Start()
 	default:


### PR DESCRIPTION
URL was a constant i.o. the url variable. Works now.