### PR TITLE
Replace underscore ("_") with space (" ")

### DIFF
--- a/youtubeuploader.go
+++ b/youtubeuploader.go
@@ -78,6 +78,8 @@ func main() {
 		*title = strings.ReplaceAll(filepath.Base(*filename), filepath.Ext(*filename), "")
 	}
 
+        *title = strings.ReplaceAll(*title, "_", " ")
+
 	var reader io.ReadCloser
 	var filesize int64
 	var err error


### PR DESCRIPTION
Uploading a file with an underscore ("_") in the filename might make the API/YoutubeUploader unresponsive.
https://imgur.com/a/j8Xq4K4
Looking at the picture, the Youtube in-browser upload manager replaces the underscore with space. But an underscore could be later added to the title. The bug is probably caused on Youtube's end, so the best solution for this problem is to replace all underscore characters with space.