### PR TITLE
Fix madeForKids example field

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Video title, description etc can specified via the command line flags or via a J
   "description": "my test description",
   "tags": ["test tag1", "test tag2"],
   "privacyStatus": "private",
-  "madeForKids": "false",
+  "madeForKids": false,
   "embeddable": true,
   "license": "creativeCommon",
   "publicStatsViewable": true,


### PR DESCRIPTION
I believe this isn't supposed to be a string in the example. When trying to use this field as a string, it failed to marshal as type bool.