### PR TITLE
add option to send video file name

### DIFF
--- a/youtubeuploader.go
+++ b/youtubeuploader.go
@@ -53,6 +53,7 @@ var (
 	chunksize         = flag.Int("chunksize", googleapi.DefaultUploadChunkSize, "size (in bytes) of each upload chunk. A zero value will cause all data to be uploaded in a single request")
 	notifySubscribers = flag.Bool("notify", true, "notify channel subscribers of new video. Specify '-notify=false' to disable.")
 	debug             = flag.Bool("debug", false, "turn on verbose log output")
+	sendFileName      = flag.Bool("sendFilename", true, "send original file name to YouTube")
 
 	// this is set by compile-time to match git tag
 	appVersion string = "unknown"
@@ -159,6 +160,11 @@ func main() {
 	option = googleapi.ChunkSize(*chunksize)
 
 	call := service.Videos.Insert([]string{"snippet", "status", "recordingDetails"}, upload)
+	if *sendFileName && *filename != "" && *filename != "-" {
+		filetitle := filepath.Base(*filename)
+		debugf("Adding file name to request: '%s'\n", filetitle)
+		call.Header().Set("Slug", filetitle)
+	}
 	video, err = call.NotifySubscribers(*notifySubscribers).Media(reader, option).Do()
 
 	quit := make(chan struct{})


### PR DESCRIPTION
When uploading videos to YouTube using the web interface, it sets the "Raw file:" entry in the "video information" section.  
However, when uploading via youtubeuploader, the file name is not set.

This pull request adds an option (which is set to "true" by default) that sends the original file title (without path) to YouTube so that it is shown when viewing video details.